### PR TITLE
Smoother difficulty retargetting

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2357,6 +2357,8 @@ bool AcceptBlockHeader(const CBlockHeader& block, CValidationState& state, CBloc
     uint256 hash = block.GetHash();
     BlockMap::iterator miSelf = mapBlockIndex.find(hash);
     CBlockIndex *pindex = NULL;
+    int64_t timeframe;
+
     if (miSelf != mapBlockIndex.end()) {
         // Block header is already known.
         pindex = miSelf->second;
@@ -2398,14 +2400,20 @@ bool AcceptBlockHeader(const CBlockHeader& block, CValidationState& state, CBloc
         if (pcheckpoint && nHeight < pcheckpoint->nHeight)
             return state.DoS(100, error("%s : forked chain older than last checkpoint (height %d)", __func__, nHeight));
 
+        if ((Params().AllowMinDifficultyBlocks() && nHeight < 300000) || nHeight < 451000) {
+            timeframe = 15 * 60;
+        } else {
+            timeframe = 5 * 60;
+        }
+
         // Prevent blocks from too far in the future (timewarp)
         if(Params().AllowMinDifficultyBlocks() || nHeight >= 100) {
-            if (block.GetBlockTime() > GetAdjustedTime() + 15 * 60) {
+            if (block.GetBlockTime() > GetAdjustedTime() + timeframe) {
                 return error("AcceptBlock() : block's timestamp too far in the future");
             }
 
             // Check timestamp is not too far in the past (timewarp)
-            if (block.GetBlockTime() <= pindexPrev->GetBlockTime() - 15 * 60) {
+            if (block.GetBlockTime() <= pindexPrev->GetBlockTime() - timeframe) {
                 return error("AcceptBlock() : block's timestamp is too early compare to last block");
             }
         }

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -76,8 +76,8 @@ unsigned int static GetNextWorkRequired_V1(const CBlockIndex* pindexLast, const 
     return bnNew.GetCompact();
 }
 
-/* current difficulty formula, DarkGravity v3, written by Evan Duffield - evan@darkcoin.io */
-unsigned int static DarkGravityWave3(const CBlockIndex* pindexLast, const CBlockHeader *pblock, int64_t version)
+// AntiGravityWave by reorder, derived from code by Evan Duffield - evan@darkcoin.io
+unsigned int static AntiGravityWave(const CBlockIndex* pindexLast, const CBlockHeader *pblock, int64_t version)
 {
     const CBlockIndex *BlockLastSolved = pindexLast;
     const CBlockIndex *BlockReading = pindexLast;
@@ -155,9 +155,9 @@ unsigned int static DarkGravityWave3(const CBlockIndex* pindexLast, const CBlock
 unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHeader *pblock)
 {
     if (pindexLast->nHeight+1 >= 451000 || (Params().AllowMinDifficultyBlocks() && pindexLast->nHeight+1 >= 300000)) {
-        return DarkGravityWave3(pindexLast, pblock, 2);
+        return AntiGravityWave(pindexLast, pblock, 2);
     } else if (pindexLast->nHeight+1 >= 3600) {
-        return DarkGravityWave3(pindexLast, pblock, 1);
+        return AntiGravityWave(pindexLast, pblock, 1);
     } else {
         return GetNextWorkRequired_V1(pindexLast, pblock);
     }

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -81,8 +81,6 @@ unsigned int static DarkGravityWave3(const CBlockIndex* pindexLast, const CBlock
 {
     const CBlockIndex *BlockLastSolved = pindexLast;
     const CBlockIndex *BlockReading = pindexLast;
-    const CBlockHeader *BlockCreating = pblock;
-    BlockCreating = BlockCreating;
     int64_t nActualTimespan = 0;
     int64_t LastBlockTime = 0;
     int64_t PastBlocksMin = 24;
@@ -127,6 +125,9 @@ unsigned int static DarkGravityWave3(const CBlockIndex* pindexLast, const CBlock
 
     uint256 bnNew(PastDifficultyAverage);
 
+    if (version == 2)
+        --CountBlocks;
+
     int64_t nTargetTimespan = CountBlocks*Params().TargetSpacing();
 
     int64_t div = 3;
@@ -153,7 +154,7 @@ unsigned int static DarkGravityWave3(const CBlockIndex* pindexLast, const CBlock
 
 unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHeader *pblock)
 {
-    if (pindexLast->nHeight+1 >= 450000 || (Params().AllowMinDifficultyBlocks() && pindexLast->nHeight+1 >= 225000)) {
+    if (pindexLast->nHeight+1 >= 451000 || (Params().AllowMinDifficultyBlocks() && pindexLast->nHeight+1 >= 300000)) {
         return DarkGravityWave3(pindexLast, pblock, 2);
     } else if (pindexLast->nHeight+1 >= 3600) {
         return DarkGravityWave3(pindexLast, pblock, 1);


### PR DESCRIPTION
Increases the sampling time and adjusting the bounds to achieve smoother retargetting.

This must also be backported to `0.10.x`

Refs #6
