### PR TITLE
Make getauxblock return True on block submission to comply with pool software

### DIFF
--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -788,7 +788,8 @@ Value getauxblock(const Array& params, bool fHelp)
                 return "inconclusive";
             state = sc.state;
         }
-        return BIP22ValidationResult(state);
+        Value result = BIP22ValidationResult(state);
+        return result.is_null() ? true : result;
     }
 }
 


### PR DESCRIPTION
`getauxblock` RPC call is modelled after `getwork` rather than `getblocktemplate`/`submitblock`, so pool software expects it to return `True` or an error string.

p2pool prints out an error message when receiving `None` instead of `True`, its other logic is unaffected.

powerpool does not update its internal statistics when receiving `None` instead of `True`, in this case it is an important issue.
