### PR TITLE
fix newer boost build with c++11

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -152,11 +152,11 @@ public:
         vSeeds.push_back(CDNSSeedData("zzy.su", "seed.zzy.su"));
         vSeeds.push_back(CDNSSeedData("bootstap.viacoin.net", "mainnet.viacoin.net"));
 
-        base58Prefixes[PUBKEY_ADDRESS] = list_of(71);
-        base58Prefixes[SCRIPT_ADDRESS] = list_of(33);
-        base58Prefixes[SECRET_KEY] =     list_of(199);
-        base58Prefixes[EXT_PUBLIC_KEY] = list_of(0x04)(0x88)(0xB2)(0x1E);
-        base58Prefixes[EXT_SECRET_KEY] = list_of(0x04)(0x88)(0xAD)(0xE4);
+        base58Prefixes[PUBKEY_ADDRESS] = std::vector<unsigned char>(71);
+        base58Prefixes[SCRIPT_ADDRESS] = std::vector<unsigned char>(33);
+        base58Prefixes[SECRET_KEY] =     std::vector<unsigned char>(199);
+        base58Prefixes[EXT_PUBLIC_KEY] = boost::assign::list_of(0x04)(0x88)(0xB2)(0x1E).convert_to_container<std::vector<unsigned char> >();
+        base58Prefixes[EXT_SECRET_KEY] = boost::assign::list_of(0x04)(0x88)(0xAD)(0xE4).convert_to_container<std::vector<unsigned char> >();
 
         convertSeed6(vFixedSeeds, pnSeed6_main, ARRAYLEN(pnSeed6_main));
 
@@ -214,11 +214,11 @@ public:
         vSeeds.push_back(CDNSSeedData("bootstrap-testnet.viacoin.net", "testnet.viacoin.net"));
         vSeeds.push_back(CDNSSeedData("viacoin.net", "seed-testnet.viacoin.net"));
 
-        base58Prefixes[PUBKEY_ADDRESS] = list_of(127);
-        base58Prefixes[SCRIPT_ADDRESS] = list_of(196);
-        base58Prefixes[SECRET_KEY]     = list_of(255);
-        base58Prefixes[EXT_PUBLIC_KEY] = list_of(0x04)(0x35)(0x87)(0xCF);
-        base58Prefixes[EXT_SECRET_KEY] = list_of(0x04)(0x35)(0x83)(0x94);
+        base58Prefixes[PUBKEY_ADDRESS] = std::vector<unsigned char>(127);
+        base58Prefixes[SCRIPT_ADDRESS] = std::vector<unsigned char>(196);
+        base58Prefixes[SECRET_KEY]     = std::vector<unsigned char>(255);
+        base58Prefixes[EXT_PUBLIC_KEY] = boost::assign::list_of(0x04)(0x35)(0x87)(0xCF).convert_to_container<std::vector<unsigned char> >();
+        base58Prefixes[EXT_SECRET_KEY] = boost::assign::list_of(0x04)(0x35)(0x83)(0x94).convert_to_container<std::vector<unsigned char> >();
 
         convertSeed6(vFixedSeeds, pnSeed6_test, ARRAYLEN(pnSeed6_test));
 

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -152,9 +152,9 @@ public:
         vSeeds.push_back(CDNSSeedData("zzy.su", "seed.zzy.su"));
         vSeeds.push_back(CDNSSeedData("bootstap.viacoin.net", "mainnet.viacoin.net"));
 
-        base58Prefixes[PUBKEY_ADDRESS] = std::vector<unsigned char>(71);
-        base58Prefixes[SCRIPT_ADDRESS] = std::vector<unsigned char>(33);
-        base58Prefixes[SECRET_KEY] =     std::vector<unsigned char>(199);
+        base58Prefixes[PUBKEY_ADDRESS] = std::vector<unsigned char>(1, 71);
+        base58Prefixes[SCRIPT_ADDRESS] = std::vector<unsigned char>(1, 33);
+        base58Prefixes[SECRET_KEY] =     std::vector<unsigned char>(1, 199);
         base58Prefixes[EXT_PUBLIC_KEY] = boost::assign::list_of(0x04)(0x88)(0xB2)(0x1E).convert_to_container<std::vector<unsigned char> >();
         base58Prefixes[EXT_SECRET_KEY] = boost::assign::list_of(0x04)(0x88)(0xAD)(0xE4).convert_to_container<std::vector<unsigned char> >();
 
@@ -214,9 +214,9 @@ public:
         vSeeds.push_back(CDNSSeedData("bootstrap-testnet.viacoin.net", "testnet.viacoin.net"));
         vSeeds.push_back(CDNSSeedData("viacoin.net", "seed-testnet.viacoin.net"));
 
-        base58Prefixes[PUBKEY_ADDRESS] = std::vector<unsigned char>(127);
-        base58Prefixes[SCRIPT_ADDRESS] = std::vector<unsigned char>(196);
-        base58Prefixes[SECRET_KEY]     = std::vector<unsigned char>(255);
+        base58Prefixes[PUBKEY_ADDRESS] = std::vector<unsigned char>(1, 127);
+        base58Prefixes[SCRIPT_ADDRESS] = std::vector<unsigned char>(1, 196);
+        base58Prefixes[SECRET_KEY]     = std::vector<unsigned char>(1, 255);
         base58Prefixes[EXT_PUBLIC_KEY] = boost::assign::list_of(0x04)(0x35)(0x87)(0xCF).convert_to_container<std::vector<unsigned char> >();
         base58Prefixes[EXT_SECRET_KEY] = boost::assign::list_of(0x04)(0x35)(0x83)(0x94).convert_to_container<std::vector<unsigned char> >();
 


### PR DESCRIPTION
From https://github.com/bitcoin/bitcoin/commit/a2b04ddfe6452e7d6274f4096bf3f2aee695a6d9

This commit fixes build errors when trying to compile viacoin 0.10.11 using c++11.